### PR TITLE
fix: Rename commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Azerothcore Quick Teleport System
 
 This module allows the server admin to configure two locations to be accesible via chat commands.
-Any player has access to the commands .home and .arena to take them to preset locations configurable
+Any player has access to the commands `.telehome` and `.telearena` to take them to preset locations configurable
 in the conf file.
 
 # Credits
 
-Shoutout to Talamortis whose Mall Teleport code was poached for the creation of this module.
+- https://github.com/azerothcore/mod-quick-teleport/graphs/contributors
+- Talamortis whose Mall Teleport code was poached for the creation of this module.

--- a/src/QuickTeleport.cpp
+++ b/src/QuickTeleport.cpp
@@ -17,8 +17,8 @@ public:
         static std::vector<ChatCommand> TeleportTable =
         {
 
-            { "home", SEC_PLAYER, false, &HandleHomeTeleportCommand, "" },
-            { "arena", SEC_PLAYER, false, &HandleArenaTeleportCommand, ""}
+            { ".telehome", SEC_PLAYER, false, &HandleHomeTeleportCommand, "" },
+            { ".telearena", SEC_PLAYER, false, &HandleArenaTeleportCommand, ""}
 
         };
         return TeleportTable;


### PR DESCRIPTION
I know, my change sux but it fixes https://github.com/azerothcore/mod-quick-teleport/issues/2